### PR TITLE
Expanding build environment variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -22,7 +22,7 @@ import java.io.IOException;
  */
 public class BuildNameSetter extends BuildWrapper {
 
-    public final String template;
+    public String template;
 
     @DataBoundConstructor
     public BuildNameSetter(String template) {
@@ -44,6 +44,7 @@ public class BuildNameSetter extends BuildWrapper {
 
     private void setDisplayName(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
         try {
+            template = build.getEnvironment(listener).expand(template);
             build.setDisplayName(TokenMacro.expand(build, listener, template));
         } catch (MacroEvaluationException e) {
             listener.getLogger().println(e.getMessage());


### PR DESCRIPTION
Small contribution to this plug-in. Custom build environment variables like parameters didn't get expanded into the build name. This functionality is now added by this request.

Also, there has been a discussion regarding this on the wiki: https://wiki.jenkins-ci.org/display/JENKINS/Build+Name+Setter+Plugin.
