### PR TITLE
Make run points configurable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ work
 *.iml
 *.ipr
 *.iws
+.DS_Store

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -17,7 +17,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.IOException;
 
 /**
- * Set the name twice.
+ * Sets the build name at two configurable points during the build.
  *
  * Once early on in the build, and another time later on.
  *
@@ -26,20 +26,30 @@ import java.io.IOException;
 public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable {
 
     public final String template;
+    public final Boolean runAtStart;
+    public final Boolean runAtEnd;
 
     @DataBoundConstructor
-    public BuildNameSetter(String template) {
+    public BuildNameSetter(String template, Boolean runAtStart, Boolean runAtEnd) {
         this.template = template;
+        this.runAtStart = runAtStart;
+        this.runAtEnd = runAtEnd;
     }
 
     @Override
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
-        setDisplayName(build, listener);
+        if (runAtStart)
+        {
+            setDisplayName(build, listener);
+        }
 
         return new Environment() {
             @Override
             public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
-                setDisplayName(build, listener);
+                if (runAtEnd)
+                {
+                    setDisplayName(build, listener);
+                }
                 return true;
             }
         };

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -3,4 +3,12 @@
 	<f:entry title="${%Build Name}" field="template">
 		<f:textbox default="#$${BUILD_NUMBER}" />
 	</f:entry>
+	<f:advanced>
+		<f:entry title="${%Set build name before build starts}">
+			<f:checkbox field="runAtStart" default="true" value="True" />
+		</f:entry>
+		<f:entry title="${%Set build name after build ends}">
+			<f:checkbox field="runAtEnd" default="true" value="True" />
+		</f:entry>
+	</f:advanced>
 </j:jelly>


### PR DESCRIPTION
If you are attempting to read a properties file for the build number and it is produced by the build, then this plugin can fail with an IOException if that properties file does not exist at the start of the build.

My solution to this was to add advanced properties to allow a job to determine when the display name is set. This allows me to produce the properties file and then read it at the end.