### PR TITLE
[JENKINS-26574] Allow distinct template for matrix head build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
       <version>1.5.1</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jvnet.hudson.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.4</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <!--

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.599</version>
+    <version>1.561</version>
   </parent>
 
   <artifactId>build-name-setter</artifactId>
@@ -32,12 +32,6 @@
       <artifactId>matrix-project</artifactId>
       <version>1.4</version>
       <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
-      <version>1.599</version>
-      <type>jar</type>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.480.3</version>
+    <version>1.599</version>
   </parent>
 
   <artifactId>build-name-setter</artifactId>
@@ -32,6 +32,12 @@
       <artifactId>matrix-project</artifactId>
       <version>1.4</version>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-core</artifactId>
+      <version>1.599</version>
+      <type>jar</type>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.jvnet.hudson.plugins</groupId>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
       <version>1.4</version>
       <optional>true</optional>

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -94,6 +94,10 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
         public String getDisplayName() {
             return "Set Build Name";
         }
+        
+        public boolean isMatrix(AbstractProject<?,?> proj){
+        	return proj instanceof MatrixProject;
+        }
     }
     public boolean isMatrix(AbstractBuild build){
     	if(build instanceof MatrixBuild){
@@ -104,7 +108,4 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
     	return isMatrix;
     }
     
-    public boolean isMatrix(AbstractProject<?,?> proj){
-    	return proj instanceof MatrixProject;
-    }
 }

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -57,6 +57,7 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
     @Override
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         try{
+        	//not checking before setting name because this check is done via Jelly call to isMatrix()
         	setDisplayName(build, listener);
         }catch(Exception e){
         	e.printStackTrace();

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -94,7 +94,7 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
 	    			build.setDisplayName(TokenMacro.expandAll(build, listener, template));
     				return;
     		case -1:
-    				throw new Exception("SetUp not performed!");
+    				throw new Exception("No valid values set for build names!");
     		}
     	} catch (MacroEvaluationException e) {
           listener.getLogger().println(e.getMessage());

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -26,16 +26,17 @@ import java.io.IOException;
 public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable {
 
     public final String template;
+    public final String matrixTemplate;
 
     @DataBoundConstructor
-    public BuildNameSetter(String template) {
+    public BuildNameSetter(String template, String matrixTemplate) {
         this.template = template;
+        this.matrixTemplate = matrixTemplate;
     }
-
+    
     @Override
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         setDisplayName(build, listener);
-
         return new Environment() {
             @Override
             public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
@@ -46,7 +47,14 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
     }
 
     private void setDisplayName(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
-        try {
+       if(matrixTemplate.length()>0){
+    	   try {
+               build.setDisplayName(TokenMacro.expandAll(build, listener, matrixTemplate));
+           } catch (MacroEvaluationException e) {
+               listener.getLogger().println(e.getMessage());
+           }  
+       }
+    	try {
             build.setDisplayName(TokenMacro.expandAll(build, listener, template));
         } catch (MacroEvaluationException e) {
             listener.getLogger().println(e.getMessage());

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -47,7 +47,7 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
     }
 
     private void setDisplayName(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
-       if(matrixTemplate.length()>0){
+       if(build instanceof MatrixBuild){
     	   try {
                build.setDisplayName(TokenMacro.expandAll(build, listener, matrixTemplate));
            } catch (MacroEvaluationException e) {

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -29,7 +29,6 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
 
     public final String template;
     public final String matrixTemplate;
-    public boolean isMatrix;
 
     @DataBoundConstructor
     public BuildNameSetter(String template, String matrixTemplate) {
@@ -57,7 +56,7 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
 
     private void setDisplayName(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
  	   try {
- 		   if(isMatrix(build)){
+ 		   if(build instanceof MatrixBuild){
 	    		build.setDisplayName(TokenMacro.expandAll(build, listener, matrixTemplate));
 	       }else{
 	    	   build.setDisplayName(TokenMacro.expandAll(build, listener, template));
@@ -98,14 +97,6 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
         public boolean isMatrix(AbstractProject<?,?> proj){
         	return proj instanceof MatrixProject;
         }
-    }
-    public boolean isMatrix(AbstractBuild build){
-    	if(build instanceof MatrixBuild){
-    		isMatrix = true;
-    	} else {
-    		isMatrix = false;
-    	}
-    	return isMatrix;
     }
     
 }

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -104,12 +104,7 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
     	return isMatrix;
     }
     
-    public boolean isMatrix(AbstractProject proj){
-    	if(proj instanceof MatrixProject){
-    		isMatrix = true;
-    	} else {
-    		isMatrix = false;
-    	}
-    	return isMatrix;
+    public boolean isMatrix(AbstractProject<?,?> proj){
+    	return proj instanceof MatrixProject;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -34,7 +34,7 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
         this.matrixTemplate = matrixTemplate;
     }
     
-    @DataBoundConstructor
+    @Deprecated
     public BuildNameSetter(String template) {
         this.template = template;
         this.matrixTemplate = null;

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -27,6 +27,7 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
 
     public final String template;
     public final String matrixTemplate;
+    public boolean isMatrix;
 
     @DataBoundConstructor
     public BuildNameSetter(String template, String matrixTemplate) {
@@ -54,7 +55,7 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
 
     private void setDisplayName(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
  	   try {
- 		   if(build instanceof MatrixBuild){
+ 		   if(isMatrix(build)){
 	    		build.setDisplayName(TokenMacro.expandAll(build, listener, matrixTemplate));
 	       }else{
 	    	   build.setDisplayName(TokenMacro.expandAll(build, listener, template));
@@ -91,5 +92,14 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
         public String getDisplayName() {
             return "Set Build Name";
         }
+    }
+    
+    public boolean isMatrix(AbstractBuild build){
+    	if(build instanceof MatrixBuild){
+    		isMatrix = true;
+    	} else {
+    		isMatrix = false;
+    	}
+    	return isMatrix;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -34,9 +34,10 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
         this.matrixTemplate = matrixTemplate;
     }
     
+    @DataBoundConstructor
     public BuildNameSetter(String template) {
         this.template = template;
-        this.matrixTemplate = "";
+        this.matrixTemplate = null;
     }
     
     @Override
@@ -52,18 +53,15 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
     }
 
     private void setDisplayName(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
-       if(build instanceof MatrixBuild){
-    	   try {
-               build.setDisplayName(TokenMacro.expandAll(build, listener, matrixTemplate));
-           } catch (MacroEvaluationException e) {
-               listener.getLogger().println(e.getMessage());
-           }  
-       }
-    	try {
-            build.setDisplayName(TokenMacro.expandAll(build, listener, template));
-        } catch (MacroEvaluationException e) {
-            listener.getLogger().println(e.getMessage());
-        }
+ 	   try {
+ 		   if(build instanceof MatrixBuild){
+	    		build.setDisplayName(TokenMacro.expandAll(build, listener, matrixTemplate));
+	       }else{
+	    	   build.setDisplayName(TokenMacro.expandAll(build, listener, template));
+	       }
+ 	  } catch (MacroEvaluationException e) {
+          listener.getLogger().println(e.getMessage());
+      }  
     }
 
     public MatrixAggregator createAggregator(MatrixBuild build, Launcher launcher, BuildListener listener) {

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -5,11 +5,13 @@ import hudson.Launcher;
 import hudson.matrix.MatrixAggregatable;
 import hudson.matrix.MatrixAggregator;
 import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
+
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -93,9 +95,17 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
             return "Set Build Name";
         }
     }
-    
     public boolean isMatrix(AbstractBuild build){
     	if(build instanceof MatrixBuild){
+    		isMatrix = true;
+    	} else {
+    		isMatrix = false;
+    	}
+    	return isMatrix;
+    }
+    
+    public boolean isMatrix(AbstractProject proj){
+    	if(proj instanceof MatrixProject){
     		isMatrix = true;
     	} else {
     		isMatrix = false;

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -34,6 +34,11 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
         this.matrixTemplate = matrixTemplate;
     }
     
+    public BuildNameSetter(String template) {
+        this.template = template;
+        this.matrixTemplate = "";
+    }
+    
     @Override
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         setDisplayName(build, listener);

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -38,7 +38,6 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
         this.template = template;
         this.matrixTemplate = matrixTemplate;
         matches = template.equals(matrixTemplate);
-        
         if(matches || matrixTemplate.length()>0 && template.length()==0){
         	scenario = 0;
         }else if (matrixTemplate.length()>0 && template.length()>0){
@@ -57,21 +56,21 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
     @Override
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         try{
-        	//not checking before setting name because this check is done via Jelly call to isMatrix()
-        	setDisplayName(build, listener);
+            //not checking before setting name because this check is done via Jelly call to isMatrix()
+            setDisplayName(build, listener);
         }catch(Exception e){
-        	e.printStackTrace();
-        	return null;
+            e.printStackTrace();
+            return null;
         }
     	return new Environment() {
             @Override
             public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
                 try {
-					setDisplayName(build, listener);
-	                return true;
-				} catch (Exception e) {
-					e.printStackTrace();
-				}
+                    setDisplayName(build, listener);
+	            return true;
+		} catch (Exception e) {
+                    e.printStackTrace();
+                }
                 return false;
             }
     	};
@@ -79,23 +78,23 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
 
     private void setDisplayName(AbstractBuild build, BuildListener listener) throws Exception {
     	try{
-    		switch(scenario){
-    		case 0:
-    	    		build.setDisplayName(TokenMacro.expandAll(build, listener, matrixTemplate));
-    				return;
-    		case 1:
-	    			if(started){	
-	    				build.setDisplayName(TokenMacro.expandAll(build, listener, matrixTemplate));
-	    			}else{
-	    				build.setDisplayName(TokenMacro.expandAll(build, listener, template));
-	    			}
-    				return;
-    		case 2:
-	    			build.setDisplayName(TokenMacro.expandAll(build, listener, template));
-    				return;
-    		case -1:
-    				throw new Exception("No valid values set for build names!");
-    		}
+            switch(scenario){
+            case 0:         
+                build.setDisplayName(TokenMacro.expandAll(build, listener, matrixTemplate));
+                return;
+            case 1:
+                if(started){	
+                    build.setDisplayName(TokenMacro.expandAll(build, listener, matrixTemplate));
+                }else{
+                    build.setDisplayName(TokenMacro.expandAll(build, listener, template));
+                }
+                return;
+            case 2:
+                build.setDisplayName(TokenMacro.expandAll(build, listener, template));
+                return;
+            case -1:
+                throw new Exception("No valid values set for build names!");
+            }
     	} catch (MacroEvaluationException e) {
           listener.getLogger().println(e.getMessage());
     	}  
@@ -106,22 +105,22 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
             @Override
             public boolean startBuild() throws InterruptedException, IOException {
                 try {
-					setDisplayName(build,listener);
-					started = true;
-	                return super.startBuild();
-				} catch (Exception e) {
-					e.printStackTrace();
-				}
+                    setDisplayName(build,listener);
+                    started = true;
+	            return super.startBuild();
+		} catch (Exception e) {
+                    e.printStackTrace();
+		}
                 return false;
             }
 
             @Override
             public boolean endBuild() throws InterruptedException, IOException {
             	try{
-            		setDisplayName(build,listener);
-            		return super.endBuild();
+                    setDisplayName(build,listener);
+                    return super.endBuild();
             	}catch(Exception e){
-            		e.printStackTrace();
+                    e.printStackTrace();
             	}
             	return false;
             }

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -51,7 +51,7 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
     @Deprecated
     public BuildNameSetter(String template) {
         this.template = template;
-        this.matrixTemplate = null;
+        this.matrixTemplate = template;
     }
     
     @Override

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -2,7 +2,7 @@
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<j:if test="${descriptor.isMatrix(it)}">
 		<f:entry title="${%Matrix Build Name}" field="matrixTemplate">
-			<f:textbox />
+			<f:textbox default="#$${BUILD_NUMBER}"/>
 		</f:entry>
 	</j:if>
 	<f:entry title="${%Build Name}" field="template">

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -3,9 +3,9 @@
 	<f:entry title="${%Build Name}" field="template">
 		<f:textbox default="#$${BUILD_NUMBER}" />
 	</f:entry>
-	<f:optionalBlock name="matrixform" test="descriptor:isMatrix(it)">
+	<j:if test="descriptor:isMatrix(it)">
 		<f:entry title="${%Matrix Build Name}" field="matrixTemplate">
 			<f:textbox default="#$${BUILD_NUMBER}" />
 		</f:entry>
-	</f:optionalBlock>
+	</j:if>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -2,10 +2,10 @@
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<j:if test="${descriptor.isMatrix(it)}">
 		<f:entry title="${%Matrix Build Name}" field="matrixTemplate">
-			<f:textbox default="#$${BUILD_NUMBER}" />
+			<f:textbox />
 		</f:entry>
 	</j:if>
 	<f:entry title="${%Build Name}" field="template">
-		<f:textbox default="#" />
+		<f:textbox default="#$${BUILD_NUMBER}" />
 	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -3,7 +3,7 @@
 	<f:entry title="${%Build Name}" field="template">
 		<f:textbox default="#$${BUILD_NUMBER}" />
 	</f:entry>
-	<j:if test="descriptor:isMatrix(it)">
+	<j:if test="descriptor:${isMatrix(it)}">
 		<f:entry title="${%Matrix Build Name}" field="matrixTemplate">
 			<f:textbox default="#$${BUILD_NUMBER}" />
 		</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -3,4 +3,7 @@
 	<f:entry title="${%Build Name}" field="template">
 		<f:textbox default="#$${BUILD_NUMBER}" />
 	</f:entry>
+	<f:entry title="${%Matrix Build Name}" field="matrixTemplate">
+		<f:textbox default="#$${BUILD_NUMBER}" />
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -3,7 +3,7 @@
 	<f:entry title="${%Build Name}" field="template">
 		<f:textbox default="#$${BUILD_NUMBER}" />
 	</f:entry>
-	<j:if test="descriptor:${isMatrix(it)}">
+	<j:if test="${descriptor.isMatrix(it)}">
 		<f:entry title="${%Matrix Build Name}" field="matrixTemplate">
 			<f:textbox default="#$${BUILD_NUMBER}" />
 		</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -6,6 +6,6 @@
 		</f:entry>
 	</j:if>
 	<f:entry title="${%Build Name}" field="template">
-		<f:textbox default="#$${BUILD_NUMBER}" />
+		<f:textbox default="" />
 	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -3,7 +3,13 @@
 	<f:entry title="${%Build Name}" field="template">
 		<f:textbox default="#$${BUILD_NUMBER}" />
 	</f:entry>
-	<f:entry title="${%Matrix Build Name}" field="matrixTemplate">
-		<f:textbox default="#$${BUILD_NUMBER}" />
-	</f:entry>
+	<f:block>
+     <table>
+		<f:optionalBlock name="matrixform" test="descriptor:isMatrix(it)">
+			<f:entry title="${%Matrix Build Name}" field="matrixTemplate">
+				<f:textbox default="#$${BUILD_NUMBER}" />
+			</f:entry>
+		</f:optionalBlock>
+	  </table>
+   </f:block>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -1,11 +1,11 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%Build Name}" field="template">
-		<f:textbox default="#$${BUILD_NUMBER}" />
-	</f:entry>
 	<j:if test="${descriptor.isMatrix(it)}">
 		<f:entry title="${%Matrix Build Name}" field="matrixTemplate">
 			<f:textbox default="#$${BUILD_NUMBER}" />
 		</f:entry>
 	</j:if>
+	<f:entry title="${%Build Name}" field="template">
+		<f:textbox default="#$${BUILD_NUMBER}" />
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -3,13 +3,9 @@
 	<f:entry title="${%Build Name}" field="template">
 		<f:textbox default="#$${BUILD_NUMBER}" />
 	</f:entry>
-	<f:block>
-     <table>
-		<f:optionalBlock name="matrixform" test="descriptor:isMatrix(it)">
-			<f:entry title="${%Matrix Build Name}" field="matrixTemplate">
-				<f:textbox default="#$${BUILD_NUMBER}" />
-			</f:entry>
-		</f:optionalBlock>
-	  </table>
-   </f:block>
+	<f:optionalBlock name="matrixform" test="descriptor:isMatrix(it)">
+		<f:entry title="${%Matrix Build Name}" field="matrixTemplate">
+			<f:textbox default="#$${BUILD_NUMBER}" />
+		</f:entry>
+	</f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/config.jelly
@@ -6,6 +6,6 @@
 		</f:entry>
 	</j:if>
 	<f:entry title="${%Build Name}" field="template">
-		<f:textbox default="" />
+		<f:textbox default="#" />
 	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/help-template.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/help-template.jelly
@@ -1,9 +1,9 @@
 <div>
     Normally, builds are named by their sequential numbers, but you can change that here by
     setting what name new build gets. This field can contain the following macros:
-
+    <br>
     <help xmlns="/lib/token-macro" />
-    
+    <br>
     For multi-configuration projects: if the Matrix Build Name is set and the Build 
     Name field is not set, then the head build and child builds will all use the Matrix Build 
     Name's pattern.

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/help-template.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/help-template.jelly
@@ -3,4 +3,13 @@
     setting what name new build gets. This field can contain the following macros:
 
     <help xmlns="/lib/token-macro" />
+    
+    For multi-configuration projects: if the Matrix Build Name is set and the Build 
+    Name field is not set, then the head build and child builds will all use the Matrix Build 
+    Name's pattern.
+    
+    If both the Matrix Build Name and default build name are set, then the Matrix Build Name
+    will only apply to the head build and child builds will use the value of the Build Name 
+    field. This is useful if child builds will take their name from a dynamically generated 
+    file.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/help-template.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter/help-template.jelly
@@ -1,9 +1,9 @@
 <div>
     Normally, builds are named by their sequential numbers, but you can change that here by
     setting what name new build gets. This field can contain the following macros:
-    <br>
+
     <help xmlns="/lib/token-macro" />
-    <br>
+
     For multi-configuration projects: if the Matrix Build Name is set and the Build 
     Name field is not set, then the head build and child builds will all use the Matrix Build 
     Name's pattern.

--- a/src/test/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetterTest.java
@@ -25,11 +25,6 @@ public class BuildNameSetterTest {
 		fooProj.getBuildWrappersList().add(new BuildNameSetter("a_#${BUILD_NUMBER}", "")); 
 		FreeStyleBuild fooBuild = fooProj.scheduleBuild2(0).get();
 		asssertDisplayName(fooBuild, "a_#1");
-		//JENKINS-26574
-		MatrixProject fooMatrix = jenkins.createMatrixProject("bar");
-		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("", "a_#${BUILD_NUMBER}")); 
-		MatrixBuild barBuild = fooMatrix.scheduleBuild2(0).get();
-		asssertDisplayName(barBuild, "a_#1");
 	}
 
 	@Test
@@ -38,11 +33,6 @@ public class BuildNameSetterTest {
 		barProj.getBuildWrappersList().add(new BuildNameSetter("b_${ENV,var=\"JOB_NAME\"}", "")); 
 		FreeStyleBuild barBuild = barProj.scheduleBuild2(0).get();
 		asssertDisplayName(barBuild, "b_bar");
-		//JENKINS-26574
-		MatrixProject fooMatrix = jenkins.createMatrixProject("foo");
-		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("", "b_${ENV,var=\"JOB_NAME\"}")); 
-		MatrixBuild fooBuild = fooMatrix.scheduleBuild2(0).get();
-		asssertDisplayName(fooBuild, "b_foo");
 	}
 
 	@Bug(13347)
@@ -52,12 +42,6 @@ public class BuildNameSetterTest {
 		barProj.getBuildWrappersList().add(new BuildNameSetter("c_${JOB_NAME}", "")); 
 		FreeStyleBuild barBuild = barProj.scheduleBuild2(0).get();
 		asssertDisplayName(barBuild, "c_bar");
-		//JENKINS-26574
-		MatrixProject fooMatrix = jenkins.createMatrixProject("foo");
-		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("", "c_${JOB_NAME}")); 
-		MatrixBuild fooBuild = fooMatrix.scheduleBuild2(0).get();
-		asssertDisplayName(fooBuild, "c_foo");
-
 	}
 
 	@Bug(13347)
@@ -67,12 +51,6 @@ public class BuildNameSetterTest {
 		barProj.getBuildWrappersList().add(new BuildNameSetter("c_${JOB_NAME}_d_${JOB_NAME}", "")); 
 		FreeStyleBuild barBuild = barProj.scheduleBuild2(0).get();
 		asssertDisplayName(barBuild, "c_bar_d_bar");
-		//JENKINS-26574
-		MatrixProject fooMatrix = jenkins.createMatrixProject("foo");
-		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("", "c_${JOB_NAME}_d_${JOB_NAME}")); 
-		MatrixBuild fooBuild = fooMatrix.scheduleBuild2(0).get();
-		asssertDisplayName(fooBuild, "c_foo_d_foo");
-		
 	}
 	
 	@Bug(13347)
@@ -82,21 +60,91 @@ public class BuildNameSetterTest {
 		fooProj.getBuildWrappersList().add(new BuildNameSetter("d_${NODE_NAME}_${ENV,var=\"JOB_NAME\"}", "")); 
 		FreeStyleBuild fooBuild = fooProj.scheduleBuild2(0).get();
 		asssertDisplayName(fooBuild, "d_master_foo");
-		//JENKINS-26574
+	}
+	@Bug(26574)
+	@Test
+	public void shouldExpand_BUILD_NUMBER_macro_matrix() throws InterruptedException, ExecutionException, IOException {
+		//JENKINS-26574 - only matrix set
+		MatrixProject barMatrix = jenkins.createMatrixProject("bar");
+		barMatrix.getBuildWrappersList().add(new BuildNameSetter("", "a_#${BUILD_NUMBER}")); 
+		MatrixBuild barBuild = barMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(barBuild, "a_#1");
+		//JENKINS-26574 - template and matrix set
+		MatrixProject fooMatrix = jenkins.createMatrixProject("foo");
+		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("a_#${BUILD_NUMBER}", "foobar")); 
+		MatrixBuild fooBuild = fooMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(fooBuild, "foobar");
+	}
+	@Bug(26574)
+	@Test
+	public void shouldExpand_JOB_NAME_full_env_macro_matrix() throws InterruptedException, ExecutionException, IOException {
+		//JENKINS-26574 - only matrix set
+		MatrixProject fooMatrix = jenkins.createMatrixProject("foo");
+		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("", "b_${ENV,var=\"JOB_NAME\"}")); 
+		MatrixBuild fooBuild = fooMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(fooBuild, "b_foo");
+		//JENKINS-26574 - template and matrix set
+		MatrixProject barMatrix = jenkins.createMatrixProject("bar");
+		barMatrix.getBuildWrappersList().add(new BuildNameSetter("b_${ENV,var=\"JOB_NAME\"}", "foobar")); 
+		MatrixBuild barBuild = barMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(barBuild, "foobar");
+	}
+
+	@Bug(26574)
+	@Test
+	public void shouldExpand_JOB_NAME_macro_matrix() throws InterruptedException, ExecutionException, IOException {
+		//JENKINS-26574 - only matrix set
+		MatrixProject fooMatrix = jenkins.createMatrixProject("foo");
+		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("", "c_${JOB_NAME}")); 
+		MatrixBuild fooBuild = fooMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(fooBuild, "c_foo");
+		//JENKINS-26574 - template and matrix set
+		MatrixProject barMatrix = jenkins.createMatrixProject("bar");
+		barMatrix.getBuildWrappersList().add(new BuildNameSetter("c_${JOB_NAME}", "foobar")); 
+		MatrixBuild barBuild = barMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(barBuild, "foobar");
+
+	}
+	@Bug(26574)
+	@Test
+	public void shouldExpand_JOB_NAME_macro_twice_matrix() throws InterruptedException, ExecutionException, IOException {
+		//JENKINS-26574 - only matrix set
+		MatrixProject fooMatrix = jenkins.createMatrixProject("foo");
+		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("", "c_${JOB_NAME}_d_${JOB_NAME}")); 
+		MatrixBuild fooBuild = fooMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(fooBuild, "c_foo_d_foo");
+		//JENKINS-26574 - template and matrix set
+		MatrixProject barMatrix = jenkins.createMatrixProject("bar");
+		barMatrix.getBuildWrappersList().add(new BuildNameSetter("c_${JOB_NAME}_d_${JOB_NAME}", "foobar")); 
+		MatrixBuild barBuild = barMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(barBuild, "foobar");
+		
+	}
+	
+	@Bug(26574)
+	@Test
+	public void shouldExpand_JOB_NAME_macro_and_JOB_NAME_full_env_macro_matrix() throws InterruptedException, ExecutionException, IOException {
+		//JENKINS-26574 - only matrix set
 		MatrixProject barMatrix = jenkins.createMatrixProject("bar");
 		barMatrix.getBuildWrappersList().add(new BuildNameSetter("", "d_${NODE_NAME}_${ENV,var=\"JOB_NAME\"}")); 
 		MatrixBuild barBuild = barMatrix.scheduleBuild2(0).get();
 		asssertDisplayName(barBuild, "d_master_bar");
-
+		//JENKINS-26574 - template and matrix set
+		MatrixProject fooMatrix = jenkins.createMatrixProject("foo");
+		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("d_${NODE_NAME}_${ENV,var=\"JOB_NAME\"}", "foobar")); 
+		MatrixBuild fooBuild = fooMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(fooBuild, "foobar");
 	}
 
+	@Bug(26574)
+	private void asssertDisplayName(MatrixBuild build, String expectedName) {
+		assertEquals(Result.SUCCESS, build.getResult());
+		assertEquals(expectedName, build.getDisplayName());
+	}
+	
 	private void asssertDisplayName(FreeStyleBuild build, String expectedName) {
 		assertEquals(Result.SUCCESS, build.getResult());
 		assertEquals(expectedName, build.getDisplayName());
 	}
 	
-	private void asssertDisplayName(MatrixBuild build, String expectedName) {
-		assertEquals(Result.SUCCESS, build.getResult());
-		assertEquals(expectedName, build.getDisplayName());
-	}
 }

--- a/src/test/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetterTest.java
@@ -1,6 +1,8 @@
 package org.jenkinsci.plugins.buildnamesetter;
 
 import static org.junit.Assert.assertEquals;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
 import hudson.model.FreeStyleProject;
@@ -20,52 +22,80 @@ public class BuildNameSetterTest {
 	@Test
 	public void shouldExpand_BUILD_NUMBER_macro() throws InterruptedException, ExecutionException, IOException {
 		FreeStyleProject fooProj = jenkins.createFreeStyleProject("foo");
-		fooProj.getBuildWrappersList().add(new BuildNameSetter("a_#${BUILD_NUMBER}")); 
-		
+		fooProj.getBuildWrappersList().add(new BuildNameSetter("a_#${BUILD_NUMBER}", "")); 
 		FreeStyleBuild fooBuild = fooProj.scheduleBuild2(0).get();
 		asssertDisplayName(fooBuild, "a_#1");
+		//JENKINS-26574
+		MatrixProject fooMatrix = jenkins.createMatrixProject("bar");
+		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("", "a_#${BUILD_NUMBER}")); 
+		MatrixBuild barBuild = fooMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(barBuild, "a_#1");
 	}
 
 	@Test
 	public void shouldExpand_JOB_NAME_full_env_macro() throws InterruptedException, ExecutionException, IOException {
 		FreeStyleProject barProj = jenkins.createFreeStyleProject("bar");
-		barProj.getBuildWrappersList().add(new BuildNameSetter("b_${ENV,var=\"JOB_NAME\"}")); 
-		
+		barProj.getBuildWrappersList().add(new BuildNameSetter("b_${ENV,var=\"JOB_NAME\"}", "")); 
 		FreeStyleBuild barBuild = barProj.scheduleBuild2(0).get();
 		asssertDisplayName(barBuild, "b_bar");
+		//JENKINS-26574
+		MatrixProject fooMatrix = jenkins.createMatrixProject("foo");
+		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("", "b_${ENV,var=\"JOB_NAME\"}")); 
+		MatrixBuild fooBuild = fooMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(fooBuild, "b_foo");
 	}
 
 	@Bug(13347)
 	@Test
 	public void shouldExpand_JOB_NAME_macro() throws InterruptedException, ExecutionException, IOException {
 		FreeStyleProject barProj = jenkins.createFreeStyleProject("bar");
-		barProj.getBuildWrappersList().add(new BuildNameSetter("c_${JOB_NAME}")); 
-		
+		barProj.getBuildWrappersList().add(new BuildNameSetter("c_${JOB_NAME}", "")); 
 		FreeStyleBuild barBuild = barProj.scheduleBuild2(0).get();
 		asssertDisplayName(barBuild, "c_bar");
+		//JENKINS-26574
+		MatrixProject fooMatrix = jenkins.createMatrixProject("foo");
+		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("", "c_${JOB_NAME}")); 
+		MatrixBuild fooBuild = fooMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(fooBuild, "c_foo");
+
 	}
 
 	@Bug(13347)
 	@Test
 	public void shouldExpand_JOB_NAME_macro_twice() throws InterruptedException, ExecutionException, IOException {
 		FreeStyleProject barProj = jenkins.createFreeStyleProject("bar");
-		barProj.getBuildWrappersList().add(new BuildNameSetter("c_${JOB_NAME}_d_${JOB_NAME}")); 
-		
+		barProj.getBuildWrappersList().add(new BuildNameSetter("c_${JOB_NAME}_d_${JOB_NAME}", "")); 
 		FreeStyleBuild barBuild = barProj.scheduleBuild2(0).get();
 		asssertDisplayName(barBuild, "c_bar_d_bar");
+		//JENKINS-26574
+		MatrixProject fooMatrix = jenkins.createMatrixProject("foo");
+		fooMatrix.getBuildWrappersList().add(new BuildNameSetter("", "c_${JOB_NAME}_d_${JOB_NAME}")); 
+		MatrixBuild fooBuild = fooMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(fooBuild, "c_foo_d_foo");
+		
 	}
 	
 	@Bug(13347)
 	@Test
 	public void shouldExpand_JOB_NAME_macro_and_JOB_NAME_full_env_macro() throws InterruptedException, ExecutionException, IOException {
 		FreeStyleProject fooProj = jenkins.createFreeStyleProject("foo");
-		fooProj.getBuildWrappersList().add(new BuildNameSetter("d_${NODE_NAME}_${ENV,var=\"JOB_NAME\"}")); 
-		
+		fooProj.getBuildWrappersList().add(new BuildNameSetter("d_${NODE_NAME}_${ENV,var=\"JOB_NAME\"}", "")); 
 		FreeStyleBuild fooBuild = fooProj.scheduleBuild2(0).get();
 		asssertDisplayName(fooBuild, "d_master_foo");
+		//JENKINS-26574
+		MatrixProject barMatrix = jenkins.createMatrixProject("bar");
+		barMatrix.getBuildWrappersList().add(new BuildNameSetter("", "d_${NODE_NAME}_${ENV,var=\"JOB_NAME\"}")); 
+		MatrixBuild barBuild = barMatrix.scheduleBuild2(0).get();
+		asssertDisplayName(barBuild, "d_master_bar");
+
 	}
 
 	private void asssertDisplayName(FreeStyleBuild build, String expectedName) {
+		assertEquals(Result.SUCCESS, build.getResult());
+		assertEquals(expectedName, build.getDisplayName());
+	}
+	
+	private void asssertDisplayName(MatrixBuild build, String expectedName) {
 		assertEquals(Result.SUCCESS, build.getResult());
 		assertEquals(expectedName, build.getDisplayName());
 	}

--- a/src/test/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetterTest.java
@@ -23,6 +23,7 @@ public class BuildNameSetterTest {
 	public void shouldExpand_BUILD_NUMBER_macro() throws InterruptedException, ExecutionException, IOException {
 		FreeStyleProject fooProj = jenkins.createFreeStyleProject("foo");
 		fooProj.getBuildWrappersList().add(new BuildNameSetter("a_#${BUILD_NUMBER}", "")); 
+		
 		FreeStyleBuild fooBuild = fooProj.scheduleBuild2(0).get();
 		asssertDisplayName(fooBuild, "a_#1");
 	}
@@ -31,6 +32,7 @@ public class BuildNameSetterTest {
 	public void shouldExpand_JOB_NAME_full_env_macro() throws InterruptedException, ExecutionException, IOException {
 		FreeStyleProject barProj = jenkins.createFreeStyleProject("bar");
 		barProj.getBuildWrappersList().add(new BuildNameSetter("b_${ENV,var=\"JOB_NAME\"}", "")); 
+		
 		FreeStyleBuild barBuild = barProj.scheduleBuild2(0).get();
 		asssertDisplayName(barBuild, "b_bar");
 	}
@@ -40,6 +42,7 @@ public class BuildNameSetterTest {
 	public void shouldExpand_JOB_NAME_macro() throws InterruptedException, ExecutionException, IOException {
 		FreeStyleProject barProj = jenkins.createFreeStyleProject("bar");
 		barProj.getBuildWrappersList().add(new BuildNameSetter("c_${JOB_NAME}", "")); 
+		
 		FreeStyleBuild barBuild = barProj.scheduleBuild2(0).get();
 		asssertDisplayName(barBuild, "c_bar");
 	}
@@ -49,6 +52,7 @@ public class BuildNameSetterTest {
 	public void shouldExpand_JOB_NAME_macro_twice() throws InterruptedException, ExecutionException, IOException {
 		FreeStyleProject barProj = jenkins.createFreeStyleProject("bar");
 		barProj.getBuildWrappersList().add(new BuildNameSetter("c_${JOB_NAME}_d_${JOB_NAME}", "")); 
+		
 		FreeStyleBuild barBuild = barProj.scheduleBuild2(0).get();
 		asssertDisplayName(barBuild, "c_bar_d_bar");
 	}
@@ -58,9 +62,11 @@ public class BuildNameSetterTest {
 	public void shouldExpand_JOB_NAME_macro_and_JOB_NAME_full_env_macro() throws InterruptedException, ExecutionException, IOException {
 		FreeStyleProject fooProj = jenkins.createFreeStyleProject("foo");
 		fooProj.getBuildWrappersList().add(new BuildNameSetter("d_${NODE_NAME}_${ENV,var=\"JOB_NAME\"}", "")); 
+		
 		FreeStyleBuild fooBuild = fooProj.scheduleBuild2(0).get();
 		asssertDisplayName(fooBuild, "d_master_foo");
 	}
+	
 	@Bug(26574)
 	@Test
 	public void shouldExpand_BUILD_NUMBER_macro_matrix() throws InterruptedException, ExecutionException, IOException {


### PR DESCRIPTION
[JENKINS-26574](https://issues.jenkins-ci.org/browse/JENKINS-26574) - Added support for Matrix projects by adding an extra field and hiding this field if the project type is not Matrix. There are 3 cases I can think of when it comes to these fields:

* template set, matrix empty (presumably != matrix build, ignore matrix field values)
* matrix set, template empty (presumably matrix build with child builds taking the same name pattern as the parent build)
* template and matrix set - use case that a CloudBees customer was asking for. Allows Matrix build name to be set explicitly and separately from spawned builds in the case where spawned builds take their name from a build-generated file.

I also added a test cases to each method to check that both case 2 and case 3 above are being set correctly.