### PR TITLE
Fix for bug JENKINS-34181 making auto unboxing NULL save + test

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -10,11 +10,14 @@ import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
+import org.apache.commons.lang.BooleanUtils;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
+
+import static org.apache.commons.lang.BooleanUtils.toBooleanDefaultIfNull;
 
 /**
  * Sets the build name at two configurable points during the build.
@@ -32,8 +35,8 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
     @DataBoundConstructor
     public BuildNameSetter(String template, Boolean runAtStart, Boolean runAtEnd) {
         this.template = template;
-        this.runAtStart = runAtStart;
-        this.runAtEnd = runAtEnd;
+        this.runAtStart = toBooleanDefaultIfNull(runAtStart, true);
+        this.runAtEnd = toBooleanDefaultIfNull(runAtEnd, true);
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetterTest.java
@@ -65,6 +65,16 @@ public class BuildNameSetterTest {
 		asssertDisplayName(fooBuild, "d_master_foo");
 	}
 
+	@Bug(34181)
+	@Test
+	public void shouldUse_default_config_values_if_null() throws InterruptedException, ExecutionException, IOException {
+		FreeStyleProject fooProj = jenkins.createFreeStyleProject("foo");
+		fooProj.getBuildWrappersList().add(new BuildNameSetter("${ENV,var=\"JOB_NAME\"}", null, null));
+
+		FreeStyleBuild fooBuild = fooProj.scheduleBuild2(0).get();
+		asssertDisplayName(fooBuild, "foo");
+	}
+
 	private void asssertDisplayName(FreeStyleBuild build, String expectedName) {
 		assertEquals(Result.SUCCESS, build.getResult());
 		assertEquals(expectedName, build.getDisplayName());


### PR DESCRIPTION
In any case were old configurations do not have values for **runAtStart** and **runAtEnd** there will be a NPE on auto unboxing the Boolean references.

This fix uses _org.apache.commons.lang.BooleanUtils.toBooleanDefaultIfNull_ to have a NULL save setting of true as the default is in the **config.jelly** file

see [https://issues.jenkins-ci.org/browse/JENKINS-34181](https://issues.jenkins-ci.org/browse/JENKINS-34181)