### PR TITLE
Fix for bug JENKINS-34415 Broken backward compatibility

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -29,8 +29,8 @@ import static org.apache.commons.lang.BooleanUtils.toBooleanDefaultIfNull;
 public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable {
 
     public final String template;
-    public boolean runAtStart = true;
-    public boolean runAtEnd = true;
+    public Boolean runAtStart = true;
+    public Boolean runAtEnd = true;
 
     @DataBoundConstructor
     public BuildNameSetter(String template, Boolean runAtStart, Boolean runAtEnd) {
@@ -39,6 +39,16 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
         this.runAtEnd = toBooleanDefaultIfNull(runAtEnd, true);
     }
 
+	protected Object readResolve() {
+        if (runAtStart == null) {
+            runAtStart = true;
+        }
+        if (runAtEnd == null) {
+			runAtEnd = true;
+        }
+        return this;
+    }
+	
     @Override
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         if (runAtStart)

--- a/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetter.java
@@ -39,12 +39,12 @@ public class BuildNameSetter extends BuildWrapper implements MatrixAggregatable 
         this.runAtEnd = toBooleanDefaultIfNull(runAtEnd, true);
     }
 
-	protected Object readResolve() {
+    protected Object readResolve() {
         if (runAtStart == null) {
             runAtStart = true;
         }
         if (runAtEnd == null) {
-			runAtEnd = true;
+            runAtEnd = true;
         }
         return this;
     }


### PR DESCRIPTION
Added readResolve method according to https://wiki.jenkins-ci.org/display/JENKINS/Hint+on+retaining+backward+compatibility in order to keep default behavior of the plugin.
Bug https://issues.jenkins-ci.org/browse/JENKINS-34415