### PR TITLE
Added missing dependency to matrix-project-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.480.3</version>
+    <version>2.19</version>
   </parent>
 
   <artifactId>build-name-setter</artifactId>
@@ -38,6 +38,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
       <version>1.5.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.11</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.19</version>
+    <version>1.609</version>
   </parent>
 
   <artifactId>build-name-setter</artifactId>
@@ -45,46 +45,6 @@
       <version>1.11</version>
     </dependency>
   </dependencies>
-
-  <!--
-  <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-war</artifactId>
-      <version>${jenkins.version}</version>
-      <type>war</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
-      <version>${jenkins.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>maven-plugin</artifactId>
-      <version>${jenkins.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>ui-samples-plugin</artifactId>
-      <version>${jenkins.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness</artifactId>
-      <version>${jenkins.version}</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-
-  <properties>
-    <jenkins.version>1.396</jenkins.version>
-  </properties>
-  -->
   
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/build-name-setter-plugin.git</connection>

--- a/src/main/java/org/jenkinsci/plugins/buildnameupdater/BuildNameUpdater.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnameupdater/BuildNameUpdater.java
@@ -1,24 +1,5 @@
 package org.jenkinsci.plugins.buildnameupdater;
 
-import hudson.EnvVars;
-import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.EnvironmentContributingAction;
-import hudson.remoting.VirtualChannel;
-import hudson.tasks.BuildStepDescriptor;
-import hudson.tasks.Builder;
-import hudson.util.FormValidation;
-import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.EnvironmentVarSetter;
-import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
-import org.jenkinsci.plugins.tokenmacro.TokenMacro;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-
 import javax.servlet.ServletException;
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,6 +7,26 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.EnvironmentVarSetter;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import jenkins.MasterToSlaveFileCallable;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.remoting.VirtualChannel;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
 
 /**
  *
@@ -161,7 +162,7 @@ public class BuildNameUpdater extends Builder {
         return (DescriptorImpl)super.getDescriptor();
     }
 
-    private static class MyFileCallable implements FilePath.FileCallable<String> {
+    private static class MyFileCallable extends MasterToSlaveFileCallable<String> {
         private static final long serialVersionUID = 1L;
 
         @Override


### PR DESCRIPTION
This plug-in is not part of the default installation anymore.

Breaks 2 JobDSL test cases, see https://jenkins.ci.cloudbees.com/job/core/job/acceptance-test-harness-stable/1596/testReport/

Followup to jenkinsci/acceptance-test-harness#337