### PR TITLE
[JENKINS-39674] - Prevent file descriptor leak in the Build Name Updater step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.2</version>
+    <version>3.5</version>
   </parent>
 
   <artifactId>build-name-setter</artifactId>
@@ -13,8 +13,6 @@
   <properties>
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
-    <!-- TODO: remove once FindBugs issues are fixed -->
-    <findbugs.failOnError>false</findbugs.failOnError>
   </properties>
 
 

--- a/src/main/java/org/jenkinsci/plugins/buildnameupdater/BuildNameUpdater.java
+++ b/src/main/java/org/jenkinsci/plugins/buildnameupdater/BuildNameUpdater.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.EnvironmentVarSetter;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
@@ -166,11 +168,13 @@ public class BuildNameUpdater extends Builder {
         private static final long serialVersionUID = 1L;
 
         @Override
+        @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "Rely on the default system encoding - legacy behavior")
         public String invoke(File file, VirtualChannel channel) throws IOException, InterruptedException {
             if (file.getAbsoluteFile().exists()){
                 LOGGER.log(Level.INFO, "File is found, reading...");
-                BufferedReader br = new BufferedReader(new FileReader(file.getAbsoluteFile()));
-                return br.readLine();
+                try (BufferedReader br = new BufferedReader(new FileReader(file.getAbsoluteFile()))) {
+                    return br.readLine();
+                }
             } else {
                 LOGGER.log(Level.WARNING, "File was not found.");
                 return "";


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-39674

Just noticed this defect in the queue.

@jenkinsci/code-reviewers @Le0Michine 
