### PR TITLE
Use the new pipeline step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pipeline {
     post {
         failure {
             // in case of failure, we'd like to have simple 'git blame' on build history :)
-            currentBuild.displayName = 'This build needs help!!!'
+            buildName "This build needs help!!!"
             buildDescription("Committer: ${GERRIT_PATCHSET_UPLOADER_NAME}")
         }
     }


### PR DESCRIPTION
Please let me know if I'm wrong to assume that `buildName` step is a shorthand for `currentBuild.displayName`. In that case, a section describing the difference between the two would be beneficial to have in `README.md`.