### PR TITLE
update token-macro version requirement to 2.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,8 @@ pipeline {
 
 # Scripting
 The power of this plugin is based on [Macro Token](https://wiki.jenkins.io/display/JENKINS/Token+Macro+Plugin) so take a look what features you can use.
+
+# CHANGELOG
+
+2.1.1 requires at least 2.15 of Token Macro Plugin
+

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.12</version>
+            <version>2.15</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Because using even older 2.13 token macro plugin makes build unstable, see #62 
So this plugin should clearly require specific newer token macro plugin, which is 2.15 currently

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
update version in pom.xml
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
