### PR TITLE
Modernize to latest versions supported by Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.16</version>
+        <version>4.51</version>
+        <relativePath/>
     </parent>
 
     <artifactId>build-name-setter</artifactId>
@@ -15,8 +16,7 @@
     <url>https://github.com/jenkinsci/build-name-setter-plugin</url>
 
     <properties>
-        <jenkins.version>2.277.2</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.346.3</jenkins.version>
         <asm.version>9.0</asm.version>
     </properties>
 
@@ -68,6 +68,13 @@
                 <artifactId>asm-util</artifactId>
                 <version>${asm.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.346.x</artifactId>
+                <version>1763.v092b_8980a_f5e</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -75,12 +82,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.15</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.18.1</version>
         </dependency>
     </dependencies>
 

--- a/src/test/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildnamesetter/BuildNameSetterTest.java
@@ -67,7 +67,7 @@ public class BuildNameSetterTest {
         fooProj.getBuildWrappersList().add(getDefaultSetter("d_${NODE_NAME}_${ENV,var=\"JOB_NAME\"}"));
 
         FreeStyleBuild fooBuild = fooProj.scheduleBuild2(0).get();
-        assertDisplayName(fooBuild, "d_master_foo");
+        assertDisplayName(fooBuild, "d_built-in_foo");
     }
 
     @Bug(34181)


### PR DESCRIPTION
Hi!

This PR aims to modernize tooling and move this plugin closer to the [recommended Jenkins baseline version](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) without making the change too big. If this goes well, I can follow up with a subsequent PR to modernize further or #73 can be rebased.

This PR was generated with an [OpenRewrite recipe](https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePluginForJava8) on [Moderne.io](https://moderne.io).
<!-- Please describe your pull request here. -->


### Testing done

Ran `mvn clean verify`. I manually updated a test because the default node changed to `built-in` starting with [LTS 2.319.1](https://www.jenkins.io/changelog-stable/#v2.319.1).

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
