### PR TITLE
Modernize to Jenkins 2.375.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.51</version>
+        <version>4.71</version>
         <relativePath/>
     </parent>
 
@@ -16,7 +16,7 @@
     <url>https://github.com/jenkinsci/build-name-setter-plugin</url>
 
     <properties>
-        <jenkins.version>2.346.3</jenkins.version>
+        <jenkins.version>2.375.4</jenkins.version>
         <asm.version>9.0</asm.version>
     </properties>
 
@@ -70,8 +70,8 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.346.x</artifactId>
-                <version>1763.v092b_8980a_f5e</version>
+                <artifactId>bom-2.375.x</artifactId>
+                <version>2198.v39c76fc308ca</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Hi!

This PR aims to modernize tooling, build on Java 11/17, and move this plugin to the [recommended](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) Jenkins baseline version. It also migrates from `javax.annotations` to SpotBugs as mentioned in the [Improve a Plugin docs](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/).

It was tested by running `mvn clean verify`.

Use this link to re-run the recipe: https://app.moderne.io/recipes/builder/w2GnS