### PR TITLE
Build on Java 11 and 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,5 @@
-// Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ],
+  [ platform: 'linux', jdk: '17' ],
+])


### PR DESCRIPTION
Hi!

This is an attempt at splitting up the previous tooling modernization PR. Since the last Java 8-compatible tooling version should also work on newer versions of Java, I thought this was worth a try to keep the build green during the migration.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizeJenkinsfile