### PR TITLE
Migrate JSR-305 annotations to SpotBugs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/EnvironmentVarSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/EnvironmentVarSetter.java
@@ -9,7 +9,7 @@ import java.util.logging.Logger;
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.EnvironmentContributingAction;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.apache.commons.lang.StringUtils;
 
 /**


### PR DESCRIPTION
SpotBugs annotations are the [recommended replacement](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) for JSR 305 annotations.

Use this link to re-run the recipe: https://app.moderne.io/recipes/builder/aX7IN