### PR TITLE
Remove unused ASM dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,24 +89,7 @@
         </pluginRepository>
     </pluginRepositories>
 
-        <dependencies>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-tree</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-analysis</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-util</artifactId>
-            </dependency>
-
+    <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>


### PR DESCRIPTION
I can't see why this plugin bundles ASM. Remove unnecessary JAR files from the plugin JPI.

### Testing done

`mvn clean verify -Dtest=InjectedTest`.