### PR TITLE
Stop testing Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@
 buildPlugin(
   useContainerAgent: true,
   failFast: false,  
-  platforms: ['linux', 'windows'],
-  jdkVersions: [11, 17, 21]
-)
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])


### PR DESCRIPTION
## Stop testing Java 11

Jenkins stopped supporting Java 11 with the release of Jenkins 2.463 (weekly) and Jenkins 2.479.1 (LTS).  Most plugins stopped spending ci.jenkins.io time to run tests that are specific to Java 11.

Let's save money and time by removing the Java 11 test configuration.  It has not found any issues that are not also found with Java 17 and Java 21.

Let's save money and time by using the Java 21 on Linux and Java 17 on Windows configuration that is used in the plugin archetype.  We've had very good results with that configuration in other plugins.  

### Testing done

None.  Relying on ci.jenkins.io to run the tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
